### PR TITLE
Fix broken functionality if legacy admin resources are not installed

### DIFF
--- a/magnolia-blossom-thymeleaf-example/pom.xml
+++ b/magnolia-blossom-thymeleaf-example/pom.xml
@@ -3,7 +3,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.eiswind</groupId>
-
     <artifactId>magnolia-blossom-thymeleaf-example</artifactId>
     <version>0.1.0-SNAPSHOT</version>
     <name>Thymeleaf Magnolia Webapp Example</name>
@@ -16,14 +15,15 @@
     <properties>
         <project.config.path>${project.basedir}/../config</project.config.path>
 
-        <magnoliaVersion>5.5.2</magnoliaVersion>
+        <magnoliaVersion>5.5.4</magnoliaVersion>
         <javaVersion>1.8</javaVersion>
         <blossomVersion>3.1.3</blossomVersion>
-        <spring.version>4.3.7.RELEASE</spring.version>
-        <thymeleaf.version>3.0.3.RELEASE</thymeleaf.version>
-        <thymeleaf.spring.version>3.0.3.RELEASE</thymeleaf.spring.version>
+        <spring.version>4.3.9.RELEASE</spring.version>
+        <thymeleaf.version>3.0.6.RELEASE</thymeleaf.version>
+        <thymeleaf.spring.version>3.0.6.RELEASE</thymeleaf.spring.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
+        
+        <magnolia-blossom-thymeleaf-module.version>0.3.3-SNAPSHOT</magnolia-blossom-thymeleaf-module.version>
     </properties>
 
     <scm>
@@ -31,6 +31,29 @@
         <developerConnection>scm:git:git@github.com:eiswind/magnolia-thymeleaf-renderer.git</developerConnection>
         <url>scm:git:git@github.com:eiswind/magnolia-thymeleaf-renderer.git</url>
     </scm>
+    
+    <repositories>
+		<repository>
+			<id>magnolia.public</id>
+			<url>https://nexus.magnolia-cms.com/content/groups/public</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>vaadin-addons</id>
+			<url>https://maven.vaadin.com/vaadin-addons</url>
+		</repository>
+		<repository>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>bintray-eiswind</id>
+			<name>bintray</name>
+			<url>http://dl.bintray.com/eiswind/maven</url>
+		</repository>
+	</repositories>
+	
     <dependencies>
         <!-- Add your project specific dependencies here: --><!-- Overlay Magnolia Empty Webapp. Alternatively, use the bundled-webapp
 			or the enterprise-webapp. Dependencies versions are already imported by parent, 
@@ -111,16 +134,13 @@
         <dependency>
             <groupId>de.eiswind</groupId>
             <artifactId>magnolia-blossom-thymeleaf-module</artifactId>
-            <version>0.3.2</version>
+            <version>${magnolia-blossom-thymeleaf-module.version}</version>
         </dependency>
         <dependency>
             <groupId>info.magnolia.blossom</groupId>
             <artifactId>magnolia-module-blossom</artifactId>
             <version>${blossomVersion}</version>
-
         </dependency>
-
-
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
@@ -136,7 +156,6 @@
             <artifactId>hibernate-validator</artifactId>
             <version>5.1.3.Final</version>
         </dependency>
-
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
@@ -144,8 +163,6 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
-
-
 
     <dependencyManagement>
         <dependencies>
@@ -197,10 +214,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-
             </plugin>
-
-
         </plugins>
 
         <pluginManagement>
@@ -239,7 +253,6 @@
                     <version>3.3</version>
                     <executions>
                         <execution>
-
                             <goals>
                                 <goal>check</goal>
                                 <goal>cpd-check</goal>
@@ -250,8 +263,7 @@
                         <linkXref>false</linkXref>
                         <sourceEncoding>utf-8</sourceEncoding>
                         <minimumTokens>100</minimumTokens>
-                        <targetJdk>1.8</targetJdk>
-
+                        <targetJdk>${javaVersion}</targetJdk>
                     </configuration>
                 </plugin>
 
@@ -323,7 +335,6 @@
                             <format>xml</format>
                         </formats>
                     </configuration>
-
                     <dependencies>
                         <dependency>
                             <groupId>org.ow2.asm</groupId>
@@ -331,7 +342,6 @@
                             <version>5.0.3</version>
                         </dependency>
                     </dependencies>
-
                 </plugin>
 
                 <plugin>
@@ -348,12 +358,7 @@
                         </execution>
                     </executions>
                 </plugin>
-
             </plugins>
-
         </pluginManagement>
-
-
     </build>
-
 </project>

--- a/magnolia-blossom-thymeleaf-module/pom.xml
+++ b/magnolia-blossom-thymeleaf-module/pom.xml
@@ -10,23 +10,21 @@
 
     <properties>
         <project.config.path>${project.basedir}/../config</project.config.path>
-        <magnoliaVersion>5.5.2</magnoliaVersion>
+        <magnoliaVersion>5.5.4</magnoliaVersion>
         <javaVersion>1.8</javaVersion>
         <blossomVersion>3.1.3</blossomVersion>
-        <spring.version>4.3.7.RELEASE</spring.version>
-        <thymeleaf.version>3.0.3.RELEASE</thymeleaf.version>
-        <thymeleaf.spring.version>3.0.3.RELEASE</thymeleaf.spring.version>
+        <spring.version>4.3.9.RELEASE</spring.version>
+        <thymeleaf.version>3.0.6.RELEASE</thymeleaf.version>
+        <thymeleaf.spring.version>3.0.6.RELEASE</thymeleaf.spring.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
     </properties>
-
 
     <scm>
         <connection>scm:git:git@github.com:eiswind/magnolia-thymeleaf-renderer.git</connection>
         <developerConnection>scm:git:git@github.com:eiswind/magnolia-thymeleaf-renderer.git</developerConnection>
         <url>scm:git:git@github.com:eiswind/magnolia-thymeleaf-renderer.git</url>
-      <tag>HEAD</tag>
-  </scm>
+      	<tag>HEAD</tag>
+  	</scm>
 
     <distributionManagement>
         <repository>
@@ -57,20 +55,17 @@
                 <activeByDefault>false</activeByDefault>
             </activation>
             <build>
-
                 <plugins>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>cobertura-maven-plugin</artifactId>
                     </plugin>
-
                 </plugins>
             </build>
         </profile>
     </profiles>
 
     <dependencies>
-
         <dependency>
             <groupId>info.magnolia.bundle</groupId>
             <artifactId>magnolia-bundled-webapp</artifactId>
@@ -86,15 +81,16 @@
                     <groupId>info.magnolia.sample</groupId>
                     <artifactId>magnolia-sample-app</artifactId>
                 </exclusion>
-
             </exclusions>
         </dependency>
+        
         <dependency>
             <groupId>info.magnolia.blossom</groupId>
             <artifactId>magnolia-module-blossom</artifactId>
             <version>${blossomVersion}</version>
             <scope>provided</scope>
         </dependency>
+        
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
@@ -107,6 +103,7 @@
             </exclusions>
             <scope>provided</scope>
         </dependency>
+        
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-aop</artifactId>
@@ -119,12 +116,13 @@
             </exclusions>
             <scope>provided</scope>
         </dependency>
+        
         <dependency>
             <groupId>org.thymeleaf</groupId>
             <artifactId>thymeleaf</artifactId>
             <version>${thymeleaf.version}</version>
-
         </dependency>
+        
         <dependency>
             <groupId>org.thymeleaf</groupId>
             <artifactId>thymeleaf-spring4</artifactId>
@@ -144,17 +142,20 @@
             <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
+        
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
+        
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
+        
         <dependency>
             <groupId>javax.servlet.jsp</groupId>
             <artifactId>javax.servlet.jsp-api</artifactId>
@@ -172,6 +173,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            
             <dependency>
                 <groupId>info.magnolia.bundle</groupId>
                 <artifactId>magnolia-bundled-webapp</artifactId>
@@ -180,8 +182,6 @@
                 <scope>import</scope>
             </dependency>
 
-
-
             <!-- TEST -->
             <dependency>
                 <groupId>junit</groupId>
@@ -189,6 +189,7 @@
                 <version>4.12</version>
                 <scope>test</scope>
             </dependency>
+            
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-all</artifactId>
@@ -203,24 +204,28 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-
             </plugin>
+            
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
             </plugin>
+            
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
             </plugin>
+            
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
+            
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -229,7 +234,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-
             </plugin>
         </plugins>
 
@@ -244,11 +248,13 @@
                         <target>${javaVersion}</target>
                     </configuration>
                 </plugin>
+                
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
                     <version>2.5</version>
                 </plugin>
+                
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
@@ -263,6 +269,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.18</version>
                 </plugin>
+                
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-pmd-plugin</artifactId>
@@ -284,13 +291,13 @@
 
                     </configuration>
                 </plugin>
+                
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>2.13</version>
                     <executions>
                         <execution>
-
                             <configuration>
                                 <configLocation>${project.config.path}/relaxed_sun_checks.xml</configLocation>
                                 <encoding>UTF-8</encoding>
@@ -311,9 +318,9 @@
                             <artifactId>checkstyle</artifactId>
                             <version>6.2</version>
                         </dependency>
-
                     </dependencies>
                 </plugin>
+                
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
@@ -345,6 +352,7 @@
                         </execution>
                     </executions>
                 </plugin>
+                
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
@@ -355,8 +363,8 @@
                             <goals><goal>jar</goal></goals>
                         </execution>
                     </executions>
-
                 </plugin>
+                
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>cobertura-maven-plugin</artifactId>
@@ -385,7 +393,6 @@
                             <version>5.0.3</version>
                         </dependency>
                     </dependencies>
-
                 </plugin>
 
                 <plugin>
@@ -399,14 +406,7 @@
                         </execution>
                     </executions>
                 </plugin>
-
-
             </plugins>
-
         </pluginManagement>
-
-
     </build>
-
-
 </project>

--- a/magnolia-blossom-thymeleaf-module/pom.xml
+++ b/magnolia-blossom-thymeleaf-module/pom.xml
@@ -35,6 +35,21 @@
             <url>https://api.bintray.com/maven/eiswind/maven/magnolia-thymeleaf/</url>
         </repository>
     </distributionManagement>
+    
+	<repositories>
+		<repository>
+			<id>magnolia.public</id>
+			<url>https://nexus.magnolia-cms.com/content/groups/public</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>vaadin-addons</id>
+			<url>https://maven.vaadin.com/vaadin-addons</url>
+		</repository>
+	</repositories>
+	
     <profiles>
         <profile>
             <id>jenkins</id>

--- a/magnolia-blossom-thymeleaf-module/src/main/java/de/eiswind/magnolia/thymeleaf/dialect/MagnoliaDialect.java
+++ b/magnolia-blossom-thymeleaf-module/src/main/java/de/eiswind/magnolia/thymeleaf/dialect/MagnoliaDialect.java
@@ -35,6 +35,8 @@ import de.eiswind.magnolia.thymeleaf.processor.CmsComponentElementProcessor;
 import de.eiswind.magnolia.thymeleaf.processor.CmsInitElementProcessor;
 import org.thymeleaf.dialect.AbstractProcessorDialect;
 import org.thymeleaf.processor.IProcessor;
+import org.thymeleaf.standard.processor.StandardXmlNsTagProcessor;
+import org.thymeleaf.templatemode.TemplateMode;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -44,16 +46,15 @@ import java.util.Set;
  */
 public class MagnoliaDialect extends AbstractProcessorDialect {
 
+	private final static String DIALECT_PREFIX = "cms";
+	private boolean addLegacyResources = false;
 
     /**
      * the magnolia dialect.
      */
     public MagnoliaDialect() {
-        super("cms", "cms", 101);
+        super(DIALECT_PREFIX, DIALECT_PREFIX, 101);
     }
-
-
-    // TODO push dialect name to processors
 
     /**
      * the magnolia processors.
@@ -61,12 +62,21 @@ public class MagnoliaDialect extends AbstractProcessorDialect {
      * @return
      */
     public Set<IProcessor> getProcessors(String dialectName) {
-        final Set<IProcessor> processors = new HashSet<IProcessor>();
-        processors.add(new CmsInitElementProcessor(dialectName));
+        final Set<IProcessor> processors = new HashSet<>();
+        
+        final CmsInitElementProcessor initProcessor = new CmsInitElementProcessor(dialectName);
+        initProcessor.setAddLegacyResources(addLegacyResources);
+        processors.add(initProcessor);
+        
         processors.add(new CmsAreaElementProcessor(dialectName));
         processors.add(new CmsComponentElementProcessor(dialectName));
+        
+        // remove xmlns:cms
+        processors.add(new StandardXmlNsTagProcessor(TemplateMode.HTML, DIALECT_PREFIX));
         return processors;
     }
-
-
+    
+    public void setAddLegacyResources(boolean addLegacyResources) {
+		this.addLegacyResources = addLegacyResources;
+	}
 }

--- a/magnolia-blossom-thymeleaf-module/src/main/java/de/eiswind/magnolia/thymeleaf/processor/AbstractCmsElementProcessor.java
+++ b/magnolia-blossom-thymeleaf-module/src/main/java/de/eiswind/magnolia/thymeleaf/processor/AbstractCmsElementProcessor.java
@@ -70,7 +70,6 @@ public abstract class AbstractCmsElementProcessor<T extends TemplatingElement> e
      * @param renderingContext the context
      * @return the teplating element
      */
-
     protected final T createElement(RenderingContext renderingContext) {
         return Components.getComponentProvider().newInstance(getTemplatingElementClass(), renderingContext);
     }

--- a/magnolia-blossom-thymeleaf-module/src/main/java/de/eiswind/magnolia/thymeleaf/processor/CmsAreaElementProcessor.java
+++ b/magnolia-blossom-thymeleaf-module/src/main/java/de/eiswind/magnolia/thymeleaf/processor/CmsAreaElementProcessor.java
@@ -77,16 +77,15 @@ public class CmsAreaElementProcessor extends AbstractCmsElementProcessor<AreaEle
         final RenderingContext renderingContext = renderingEngine.getRenderingContext();
 
         AreaDefinition areaDef = null;
-        BlossomTemplateDefinition templateDefinition;
+        
         try {
-
-            templateDefinition = (BlossomTemplateDefinition) renderingContext.getRenderableDefinition();
+        	BlossomTemplateDefinition templateDefinition = 
+        			(BlossomTemplateDefinition) renderingContext.getRenderableDefinition();
+            
             if (templateDefinition.getAreas().containsKey(attributeValue)) {
                 areaDef = templateDefinition.getAreas().get(attributeValue);
             }
-
         } catch (ClassCastException x) {
-
             throw new TemplateProcessingException("Only Blossom, templates supported", x);
         }
 
@@ -94,9 +93,8 @@ public class CmsAreaElementProcessor extends AbstractCmsElementProcessor<AreaEle
             throw new TemplateProcessingException("Area not found:" + attributeValue);
         }
 
-        AreaElement areaElement = createElement(renderingContext);
+        final AreaElement areaElement = createElement(renderingContext);
         areaElement.setName(areaDef.getName());
         processElement(context, tag, structureHandler, areaElement);
     }
-
 }

--- a/magnolia-blossom-thymeleaf-module/src/main/java/de/eiswind/magnolia/thymeleaf/processor/CmsComponentElementProcessor.java
+++ b/magnolia-blossom-thymeleaf-module/src/main/java/de/eiswind/magnolia/thymeleaf/processor/CmsComponentElementProcessor.java
@@ -59,7 +59,6 @@ public class CmsComponentElementProcessor extends AbstractCmsElementProcessor<Co
      * instance.
      */
     public CmsComponentElementProcessor(String prefix) {
-
         super(TemplateMode.HTML, prefix, null, false, ATTR_NAME, true);
     }
 
@@ -93,7 +92,5 @@ public class CmsComponentElementProcessor extends AbstractCmsElementProcessor<Co
         ComponentElement componentElement = createElement(renderingContext);
         componentElement.setContent(content);
         processElement(context, tag, structureHandler, componentElement);
-
-
     }
 }

--- a/magnolia-blossom-thymeleaf-module/src/main/java/de/eiswind/magnolia/thymeleaf/renderer/ThymeleafRenderer.java
+++ b/magnolia-blossom-thymeleaf-module/src/main/java/de/eiswind/magnolia/thymeleaf/renderer/ThymeleafRenderer.java
@@ -52,14 +52,8 @@ import java.util.Set;
  */
 public class ThymeleafRenderer extends AbstractRenderer implements ServletContextAware, ApplicationContextAware {
 
-
-    //private final Logger log = LoggerFactory.getLogger(getClass());
-
     private SpringTemplateEngine engine;
-
     private ApplicationContext applicationContext;
-
-
     private ServletContext servletContext;
 
 
@@ -101,16 +95,13 @@ public class ThymeleafRenderer extends AbstractRenderer implements ServletContex
         }
         try (AppendableWriter out = renderingCtx.getAppendable()) {
             // allow template fragment syntax to be used e.g. template.html :: area
-
             Context context = new Context(MgnlContext.getLocale(), vars);
+            
             // and pass the fragment name and spec then onto the engine
             engine.process(templateScript, selectors, context, new AppendableWriterWrapper(out));
-
         } catch (IOException x) {
             throw new RenderException(x);
         }
-
-
     }
 
     /**
@@ -129,7 +120,6 @@ public class ThymeleafRenderer extends AbstractRenderer implements ServletContex
                                            final RenderingModel<?> model, final String actionResult) {
         return RenderContext.get().getTemplateScript();
     }
-
 
     public SpringTemplateEngine getEngine() {
         return engine;
@@ -154,6 +144,4 @@ public class ThymeleafRenderer extends AbstractRenderer implements ServletContex
     public void setApplicationContext(final ApplicationContext applicationContext1) {
         this.applicationContext = applicationContext1;
     }
-
-
 }

--- a/magnolia-blossom-thymeleaf-module/src/test/java/de/eiswind/magnolia/thymeleaf/processor/CmsInitTest.java
+++ b/magnolia-blossom-thymeleaf-module/src/test/java/de/eiswind/magnolia/thymeleaf/processor/CmsInitTest.java
@@ -1,6 +1,8 @@
 package de.eiswind.magnolia.thymeleaf.processor;
 
 import de.eiswind.magnolia.thymeleaf.base.AbstractMockMagnoliaTest;
+
+import org.junit.Before;
 import org.junit.Test;
 import org.thymeleaf.IEngineConfiguration;
 import org.thymeleaf.context.ITemplateContext;
@@ -22,25 +24,47 @@ import static org.mockito.Mockito.when;
  */
 public class CmsInitTest extends AbstractMockMagnoliaTest {
 
-    @Test
-    public void testCmsInit() {
-        CmsInitElementProcessor processor = new CmsInitElementProcessor("cms");
-        ITemplateContext templateContext = mock(ITemplateContext.class);
-        IEngineConfiguration configuration = renderer.getEngine().getConfiguration();
+	ITemplateContext templateContext;
+	IEngineConfiguration configuration;
+	IModelFactory modelFactory;
+	IModel model;
+	IElementModelStructureHandler structureHandler;
+	
+	@Before
+	public void before() {
+		templateContext = mock(ITemplateContext.class);
+		configuration = renderer.getEngine().getConfiguration();
+		modelFactory = configuration.getModelFactory(TemplateMode.HTML);
+		model = mock(IModel.class);
+		structureHandler = mock(IElementModelStructureHandler.class);
+		
         when(templateContext.getConfiguration()).thenReturn(configuration);
         when(templateContext.getTemplateMode()).thenReturn(TemplateMode.HTML);
-        IModelFactory modelFactory = configuration.getModelFactory(TemplateMode.HTML);
+        
         IOpenElementTag tag = modelFactory.createOpenElementTag("head");
-        modelFactory.setAttribute(tag,"cms:init", "");
-        IModel model = mock(IModel.class);
-        // we cannot use the real model because of access restrictions, so this test is pretty limited
+        tag = modelFactory.setAttribute(tag,"cms:init", "");
         when(model.get(0)).thenReturn(tag);
-        IElementModelStructureHandler structureHandler = mock(IElementModelStructureHandler.class);
-
+	}
+	
+    @Test
+    public void testCmsInitLegacy() {
+        CmsInitElementProcessor processor = new CmsInitElementProcessor("cms");
+        processor.setAddLegacyResources(true);
+        
         processor.doProcess(templateContext, model, structureHandler);
 
         verify(model).get(0);
-        verify(model, times(13)).insert(anyInt(), any());
+        verify(model, times(20)).insert(anyInt(), any());
+    }
+    
+    @Test
+    public void testCmsInitDefault() {
+        CmsInitElementProcessor processor = new CmsInitElementProcessor("cms");
+        processor.setAddLegacyResources(false);
+        
+        processor.doProcess(templateContext, model, structureHandler);
 
+        verify(model).get(0);
+        verify(model, times(3)).insert(anyInt(), any());
     }
 }

--- a/magnolia-blossom-thymeleaf-module/src/test/java/de/eiswind/magnolia/thymeleaf/processor/CmsInitTest.java
+++ b/magnolia-blossom-thymeleaf-module/src/test/java/de/eiswind/magnolia/thymeleaf/processor/CmsInitTest.java
@@ -54,7 +54,7 @@ public class CmsInitTest extends AbstractMockMagnoliaTest {
         processor.doProcess(templateContext, model, structureHandler);
 
         verify(model).get(0);
-        verify(model, times(20)).insert(anyInt(), any());
+        verify(model, times(23)).insert(anyInt(), any());
     }
     
     @Test
@@ -65,6 +65,6 @@ public class CmsInitTest extends AbstractMockMagnoliaTest {
         processor.doProcess(templateContext, model, structureHandler);
 
         verify(model).get(0);
-        verify(model, times(3)).insert(anyInt(), any());
+        verify(model, times(6)).insert(anyInt(), any());
     }
 }

--- a/magnolia-blossom-thymeleaf-module/src/test/java/de/eiswind/magnolia/thymeleaf/renderer/RendererTest.java
+++ b/magnolia-blossom-thymeleaf-module/src/test/java/de/eiswind/magnolia/thymeleaf/renderer/RendererTest.java
@@ -28,6 +28,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -58,6 +59,7 @@ public class RendererTest extends AbstractMockMagnoliaTest {
         renderer.onRender(node, renderableDefinition, renderingContext, vars, "main.html");
         String result = stringWriter.toString();
         assertTrue("cms:init was not rendered", result.contains("<!-- cms:page"));
+        assertFalse("xmlns:cms was not removed", result.matches("xmlns:cms=\"[^\"]+\""));
     }
 
     @Test


### PR DESCRIPTION
Hi,

I'd be glad if you could review this pull request and merge/release it.

The general motivation was that the current release (0.3.2) completly breaks functionality (at least in chrome and if legacy admin resources are not installed).

In detail it
* makes the addition of the admin legacy resources (CSS + JS) optional
* fixes the creation of <script> tags, which should not be standalone tags (standalone tags completly break functionality - at least in chrome and if resources are not found)
* upgrades magnlia, thymeleaf and spring to their latest minor versions
* adds a processor, which removes xmlns:cms attribute
* some small cleanups and refactorings

Apart from the fact, that addLegacyResources is false by default, the changes should not break any existing functionality. Tests run fine, but please mind that I didn't have any possibility to check the correct working when addLegacyResources == true other than compare it with the current output (which matches, apart from non-self-closing tags).

I hope this is OK.

Many thanks
Philipp